### PR TITLE
[FEATURE] Introduce `InjectVariablesViewHelper`

### DIFF
--- a/Classes/Event/ViewHelpers/ModifyInjectVariablesViewHelperEvent.php
+++ b/Classes/Event/ViewHelpers/ModifyInjectVariablesViewHelperEvent.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WebVision\Deepl\Base\Event\ViewHelpers;
+
+use TYPO3Fluid\Fluid\Core\Variables\VariableProviderInterface;
+use WebVision\Deepl\Base\ViewHelpers\InjectVariablesViewHelper;
+
+/**
+ * {@see InjectVariablesViewHelper} fires this event allow assigning additional variables
+ * to either the {@see self::$localVariableProvider} local (children) context or in global
+ * context of the currently used template {@see InjectVariablesViewHelper}.
+ */
+final class ModifyInjectVariablesViewHelperEvent
+{
+    public function __construct(
+        private readonly string $identifier,
+        private readonly VariableProviderInterface $globalVariableProvider,
+        private readonly VariableProviderInterface $localVariableProvider,
+    ) {
+    }
+
+    public function getIdentifier(): string
+    {
+        return $this->identifier;
+    }
+
+    /**
+     * Holds global variables used within the current fluid template, and which will be available
+     * after the {@see InjectVariablesViewHelper} ViewHelper call in a given template.
+     *
+     * Can be used to enrich a template in a more generic way.
+     */
+    public function getGlobalVariableProvider(): VariableProviderInterface
+    {
+        return $this->globalVariableProvider;
+    }
+
+    /**
+     * Holds variable only usable within the children block of the {@see InjectVariablesViewHelper}.
+     *
+     * Can be used to set only variables for the children context of given identifier.
+     */
+    public function getLocalVariableProvider(): VariableProviderInterface
+    {
+        return $this->localVariableProvider;
+    }
+}

--- a/Classes/ViewHelpers/InjectVariablesViewHelper.php
+++ b/Classes/ViewHelpers/InjectVariablesViewHelper.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WebVision\Deepl\Base\ViewHelpers;
+
+use Psr\EventDispatcher\EventDispatcherInterface;
+use TYPO3Fluid\Fluid\Core\Variables\ScopedVariableProvider;
+use TYPO3Fluid\Fluid\Core\Variables\StandardVariableProvider;
+use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
+use WebVision\Deepl\Base\Event\ViewHelpers\ModifyInjectVariablesViewHelperEvent;
+
+/**
+ * Allows to declare variables in global or local context variables based on a specified `identifier`
+ * using PSR-14 EventListener on event {@see ModifyInjectVariablesViewHelperEvent}.
+ */
+final class InjectVariablesViewHelper extends AbstractViewHelper
+{
+    public function __construct(
+        private EventDispatcherInterface $eventDispatcher,
+    ) {
+    }
+
+    public function initializeArguments(): void
+    {
+        $this->registerArgument('identifier', 'string', 'Unique identifier for the place', true);
+    }
+
+    public function render(): string
+    {
+        $globalVariableProvider = $this->renderingContext->getVariableProvider();
+        $localVariableProvider = new StandardVariableProvider();
+        /** @phpstan-ignore-next-line  */
+        $identifier = (string)($this->arguments['identifier'] ?? '');
+        if ($identifier === '') {
+            throw new \InvalidArgumentException(
+                'InjectVariableViewHelper argument "identifier" must be a non-empty string.',
+                1748872475,
+            );
+        }
+        $event = $this->eventDispatcher->dispatch(new ModifyInjectVariablesViewHelperEvent(
+            identifier: $identifier,
+            globalVariableProvider: $globalVariableProvider,
+            localVariableProvider: $localVariableProvider,
+        ));
+        $globalVariableProvider = $event->getGlobalVariableProvider();
+        $localVariableProvider = $event->getLocalVariableProvider();
+        $scopedVariableProvider = new ScopedVariableProvider($globalVariableProvider, $localVariableProvider);
+        // Render children with combined global and local variable context
+        $this->renderingContext->setVariableProvider($scopedVariableProvider);
+        /** @phpstan-ignore-next-line  */
+        $value = (string)$this->renderChildren();
+        // Restore enriched global variables
+        $this->renderingContext->setVariableProvider($globalVariableProvider);
+        // Return rendered children.
+        return $value;
+    }
+}

--- a/README.md
+++ b/README.md
@@ -47,3 +47,59 @@ composer require 'web-vision/deepl-base':'1.*.*@dev'
 composer config minimum-stability "dev" \
 && composer config "prefer-stable" true
 ```
+
+## Documentation
+
+> [!NOTE]
+> For the start the documentation for developers and integrators are contained
+> here in the README.md file and will be converted into a rendered documentation
+> at a later point.
+
+### PageLayout module localization model - Translation Modes
+
+### ViewHelper
+
+#### InjectVariablesViewHelper
+
+`InjectVariablesViewHelper` can be placed in fluid templates and
+requires to define a speaking identifier used to dispatch the PSR-14
+`ModifyInjectVariablesViewHelperEvent` event, which can be used to
+set or modify variables either in the global current template scope
+or for children rendering scope.
+
+##### Example usage in fluid template
+
+```xhtml
+<html
+    data-namespace-typo3-fluid="true"
+    xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
+    xmlns:deeplbase="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
+>
+<deeplbase:injectVariables identifier="custom-template-variable-inject">
+    Render {globalOrLocalVariableProviderVariable} only available in children
+    context.
+</deeplbase:injectVariables>
+Render {globalOnlyVariableProviderVariable} only ignoring local variable provider
+changes.
+</html>
+```
+
+##### ModifyInjectVariablesViewHelperEvent
+
+* `getIdentifier(): string`: identifier used within the fluid template and
+  should
+* `getGlobalVariableProvider(): VariableProviderInterface`: provides the
+  fluid variable container of the current context. Modification will be
+  available after the ViewHelper and within the children context unless
+  overridden within the `getLocalVariableProvider`.
+* `getLocalVariableProvider(): VariableProviderInterface`: provides the
+  fluid variable container with children context only variables, overriding
+  global variables. Local variable does not change the variables in the
+  template after the ViewHelper call.
+
+### Modified Backend Templates
+
+> [!NOTE]
+> Modifed backend templates are listed here describing the modification, for
+> example if one or more [InjectVariableViewhelper](#injectvariablesviewhelper)
+> has been places along with the identifier and use-case.

--- a/Tests/Functional/ViewHelpers/InjectVariablesViewHelperTest.php
+++ b/Tests/Functional/ViewHelpers/InjectVariablesViewHelperTest.php
@@ -1,0 +1,159 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WebVision\Deepl\Base\Tests\Functional\ViewHelpers;
+
+use PHPUnit\Framework\Attributes\Test;
+use SBUERK\TYPO3\Testing\TestCase\FunctionalTestCase;
+use Symfony\Component\DependencyInjection\Container;
+use TYPO3\CMS\Core\EventDispatcher\ListenerProvider;
+use TYPO3\CMS\Fluid\Core\Rendering\RenderingContextFactory;
+use TYPO3Fluid\Fluid\View\TemplateView;
+use WebVision\Deepl\Base\Event\ViewHelpers\ModifyInjectVariablesViewHelperEvent;
+
+final class InjectVariablesViewHelperTest extends FunctionalTestCase
+{
+    protected bool $initializeDatabase = false;
+
+    protected array $testExtensionsToLoad = [
+        'web-vision/deepl-base',
+    ];
+
+    #[Test]
+    public function globalVariablesCanBeUsedInChildrenWhenNotModifiedByDispatchedEvent(): void
+    {
+        $context = $this->get(RenderingContextFactory::class)->create();
+        $context->getViewHelperResolver()->addNamespace('deeplbase', 'WebVision\\Deepl\\Base\\ViewHelpers');
+        $context->getTemplatePaths()->setTemplateSource('<deeplbase:injectVariables identifier="no-event-modifications">CHECK: {templateVariable}</deeplbase:injectVariables>');
+        $context->getVariableProvider()->add('templateVariable', 'test1234');
+        $expected = 'CHECK: test1234';
+
+        $this->assertSame($expected, (new TemplateView($context))->render());
+    }
+
+    #[Test]
+    public function modifyInjectVariablesViewHelperEventIsDispatched(): void
+    {
+        /** @var ModifyInjectVariablesViewHelperEvent[] $dispatchedEvents */
+        $dispatchedEvents = [];
+        /** @var Container $container */
+        $container = $this->get('service_container');
+        $container->set(
+            'modify-inject-variables-event-is-dispatched',
+            static function (ModifyInjectVariablesViewHelperEvent $event) use (
+                &$dispatchedEvents
+            ) {
+                $dispatchedEvents[] = $event;
+            }
+        );
+        $listenerProvider = $container->get(ListenerProvider::class);
+        $listenerProvider->addListener(ModifyInjectVariablesViewHelperEvent::class, 'modify-inject-variables-event-is-dispatched');
+        $context = $this->get(RenderingContextFactory::class)->create();
+        $context->getViewHelperResolver()->addNamespace('deeplbase', 'WebVision\\Deepl\\Base\\ViewHelpers');
+        $context->getTemplatePaths()->setTemplateSource('<deeplbase:injectVariables identifier="event-is-dispatched-identifier">some value</deeplbase:injectVariables>');
+        $expected = 'some value';
+
+        $this->assertSame($expected, (new TemplateView($context))->render());
+        $this->assertCount(1, $dispatchedEvents);
+        $firstEvent = $dispatchedEvents[array_key_first($dispatchedEvents)];
+        $this->assertSame('event-is-dispatched-identifier', $firstEvent->getIdentifier());
+    }
+
+    #[Test]
+    public function modifyInjectVariablesViewHelperEventIsDispatchedMultipleTimes(): void
+    {
+        /** @var ModifyInjectVariablesViewHelperEvent[] $dispatchedEvents */
+        $dispatchedEvents = [];
+        /** @var Container $container */
+        $container = $this->get('service_container');
+        $container->set(
+            'modify-inject-variables-event-is-dispatched-multiple-times',
+            static function (ModifyInjectVariablesViewHelperEvent $event) use (
+                &$dispatchedEvents
+            ) {
+                $dispatchedEvents[] = $event;
+            }
+        );
+        $listenerProvider = $container->get(ListenerProvider::class);
+        $listenerProvider->addListener(ModifyInjectVariablesViewHelperEvent::class, 'modify-inject-variables-event-is-dispatched-multiple-times');
+        $context = $this->get(RenderingContextFactory::class)->create();
+        $context->getViewHelperResolver()->addNamespace('deeplbase', 'WebVision\\Deepl\\Base\\ViewHelpers');
+        $context->getTemplatePaths()->setTemplateSource('<deeplbase:injectVariables identifier="event-is-dispatched-identifier">some value</deeplbase:injectVariables> <deeplbase:injectVariables identifier="another-variables-inject-event">other value</deeplbase:injectVariables>');
+        $expected = 'some value other value';
+
+        $this->assertSame($expected, (new TemplateView($context))->render());
+        $this->assertCount(2, $dispatchedEvents);
+        $firstEvent = array_shift($dispatchedEvents);
+        $secondEvent = array_shift($dispatchedEvents);
+        $this->assertInstanceOf(ModifyInjectVariablesViewHelperEvent::class, $firstEvent);
+        $this->assertInstanceOf(ModifyInjectVariablesViewHelperEvent::class, $secondEvent);
+        $this->assertSame('event-is-dispatched-identifier', $firstEvent->getIdentifier());
+        $this->assertSame('another-variables-inject-event', $secondEvent->getIdentifier());
+    }
+
+    #[Test]
+    public function modifyInjectVariablesViewHelperEventIsDispatchedAndLocalVariableCanBeSetRestoringToOriginalGlobalAfterwards(): void
+    {
+        /** @var ModifyInjectVariablesViewHelperEvent[] $dispatchedEvents */
+        $dispatchedEvents = [];
+        /** @var Container $container */
+        $container = $this->get('service_container');
+        $container->set(
+            'modify-inject-variables-event-is-dispatched',
+            static function (ModifyInjectVariablesViewHelperEvent $event) use (
+                &$dispatchedEvents
+            ) {
+                if ($event->getIdentifier() === 'modify-variables') {
+                    $event->getLocalVariableProvider()->add('testVariable', 'local-replacement');
+                }
+                $dispatchedEvents[] = $event;
+            }
+        );
+        $listenerProvider = $container->get(ListenerProvider::class);
+        $listenerProvider->addListener(ModifyInjectVariablesViewHelperEvent::class, 'modify-inject-variables-event-is-dispatched');
+        $context = $this->get(RenderingContextFactory::class)->create();
+        $context->getViewHelperResolver()->addNamespace('deeplbase', 'WebVision\\Deepl\\Base\\ViewHelpers');
+        $context->getTemplatePaths()->setTemplateSource('START: {testVariable} <deeplbase:injectVariables identifier="modify-variables">LOCAL: {testVariable}</deeplbase:injectVariables> AFTER: {testVariable}');
+        $context->getVariableProvider()->add('testVariable', 'global-start');
+        $expected = 'START: global-start LOCAL: local-replacement AFTER: global-start';
+
+        $this->assertSame($expected, (new TemplateView($context))->render());
+        $this->assertCount(1, $dispatchedEvents);
+        $firstEvent = $dispatchedEvents[array_key_first($dispatchedEvents)];
+        $this->assertSame('modify-variables', $firstEvent->getIdentifier());
+    }
+
+    #[Test]
+    public function modifyInjectVariablesViewHelperEventIsDispatchedAndModifiedGlobalVariablesIsAvailableAfterwards(): void
+    {
+        /** @var ModifyInjectVariablesViewHelperEvent[] $dispatchedEvents */
+        $dispatchedEvents = [];
+        /** @var Container $container */
+        $container = $this->get('service_container');
+        $container->set(
+            'modify-inject-variables-event-is-dispatched',
+            static function (ModifyInjectVariablesViewHelperEvent $event) use (
+                &$dispatchedEvents
+            ) {
+                if ($event->getIdentifier() === 'modify-variables') {
+                    $event->getLocalVariableProvider()->add('testVariable', 'local-replacement');
+                    $event->getGlobalVariableProvider()->add('testVariable', 'global-after');
+                }
+                $dispatchedEvents[] = $event;
+            }
+        );
+        $listenerProvider = $container->get(ListenerProvider::class);
+        $listenerProvider->addListener(ModifyInjectVariablesViewHelperEvent::class, 'modify-inject-variables-event-is-dispatched');
+        $context = $this->get(RenderingContextFactory::class)->create();
+        $context->getViewHelperResolver()->addNamespace('deeplbase', 'WebVision\\Deepl\\Base\\ViewHelpers');
+        $context->getTemplatePaths()->setTemplateSource('START: {testVariable} <deeplbase:injectVariables identifier="modify-variables">LOCAL: {testVariable}</deeplbase:injectVariables> AFTER: {testVariable}');
+        $context->getVariableProvider()->add('testVariable', 'global-start');
+        $expected = 'START: global-start LOCAL: local-replacement AFTER: global-after';
+
+        $this->assertSame($expected, (new TemplateView($context))->render());
+        $this->assertCount(1, $dispatchedEvents);
+        $firstEvent = $dispatchedEvents[array_key_first($dispatchedEvents)];
+        $this->assertSame('modify-variables', $firstEvent->getIdentifier());
+    }
+}


### PR DESCRIPTION
This change introduces the `InjectVariablesViewHelper`, which
can be invoked multiple times with a `identifier´.

The ViewHelper dispatches the new `ModifyInjectVariablesViewHelperEvent`
containing the identifier, the global and local variable provider.

Assigned variables to the global variable provider will be available
within the children context of the ViewHelper but also remains valid
after the ViewHelper call within the fluid template context using it.

The local variable provider on the otherhand makes the variables only
available for the children rendering (between the ViewHelper tags).

That allows as much control as possible. Usages of this ViewHelper
needs to be documented along with the provider and expected must-have
variables (and in which context).

With this ViewHelper it is possible to override a TYPO3 Backend Fluid
template once using this ViewHelper to define additional Variables or
a variable containing a list of for example partials which should be
rendered as a loop within the overriden template.

