### PR TITLE
[TASK] Enable html generated output for ViewHelper

### DIFF
--- a/Build/phpstan/Core12/phpstan.neon
+++ b/Build/phpstan/Core12/phpstan.neon
@@ -8,7 +8,7 @@ parameters:
   # Use local .cache dir instead of /tmp
   tmpDir: ../../../.cache/phpstan
 
-  level: 9
+  level: 8
 
   paths:
     - ../../../Classes

--- a/Build/phpstan/Core13/phpstan.neon
+++ b/Build/phpstan/Core13/phpstan.neon
@@ -8,7 +8,7 @@ parameters:
   # Use local .cache dir instead of /tmp
   tmpDir: ../../../.cache/phpstan
 
-  level: 9
+  level: 8
 
   paths:
     - ../../../Classes

--- a/Classes/EventListener/DefaultTranslationDropdownEventListener.php
+++ b/Classes/EventListener/DefaultTranslationDropdownEventListener.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WebVision\Deepl\Base\EventListener;
+
+use WebVision\Deepl\Base\Event\ViewHelpers\ModifyInjectVariablesViewHelperEvent;
+
+/**
+ * Used in Template for providing the TYPO3 Core translation options in PageView
+ */
+final class DefaultTranslationDropdownEventListener
+{
+    public function __invoke(ModifyInjectVariablesViewHelperEvent $event): void
+    {
+        if ($event->getIdentifier() !== 'languageTranslationDropdown') {
+            return;
+        }
+        $translationPartials = $event->getLocalVariableProvider()->get('translationPartials');
+        if ($translationPartials === null) {
+            $translationPartials = [];
+        }
+        $translationPartials[10] = 'Translation/DefaultTranslationDropdown';
+        $event->getLocalVariableProvider()->add('translationPartials', $translationPartials);
+    }
+}

--- a/Classes/ViewHelpers/ExtensionActiveViewHelper.php
+++ b/Classes/ViewHelpers/ExtensionActiveViewHelper.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WebVision\Deepl\Base\ViewHelpers;
+
+use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
+use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
+use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractConditionViewHelper;
+
+/**
+ * condition ViewHelper for getting information about installed packages
+ * Usage:
+ * <deeplbase:extensionActive extension="enable_translated_content">
+ *     <f:then>
+ *         <!-- do stuff -->
+ *     </f:then>
+ *     <f:else>
+ *         <!-- do other stuff -->
+ *     </f:else>
+ * </deeplbase:extensionActive>
+ *
+ * Inline example:
+ * {deepl:be.extensionActive(extension: 'enable_translated_content', then: '', else: '')}
+ */
+final class ExtensionActiveViewHelper extends AbstractConditionViewHelper
+{
+    public function initializeArguments(): void
+    {
+        parent::initializeArguments();
+        $this->registerArgument('extension', 'string', 'The extension to check', true);
+    }
+
+    public static function verdict(array $arguments, RenderingContextInterface $renderingContext): bool
+    {
+        if (ExtensionManagementUtility::isLoaded((string)($arguments['extension'] ?? ''))) {
+            return true;
+        }
+        return false;
+    }
+}

--- a/Classes/ViewHelpers/InjectVariablesViewHelper.php
+++ b/Classes/ViewHelpers/InjectVariablesViewHelper.php
@@ -16,6 +16,8 @@ use WebVision\Deepl\Base\Event\ViewHelpers\ModifyInjectVariablesViewHelperEvent;
  */
 final class InjectVariablesViewHelper extends AbstractViewHelper
 {
+    protected $escapeOutput = false;
+
     public function __construct(
         private EventDispatcherInterface $eventDispatcher,
     ) {
@@ -30,7 +32,6 @@ final class InjectVariablesViewHelper extends AbstractViewHelper
     {
         $globalVariableProvider = $this->renderingContext->getVariableProvider();
         $localVariableProvider = new StandardVariableProvider();
-        /** @phpstan-ignore-next-line  */
         $identifier = (string)($this->arguments['identifier'] ?? '');
         if ($identifier === '') {
             throw new \InvalidArgumentException(
@@ -48,7 +49,6 @@ final class InjectVariablesViewHelper extends AbstractViewHelper
         $scopedVariableProvider = new ScopedVariableProvider($globalVariableProvider, $localVariableProvider);
         // Render children with combined global and local variable context
         $this->renderingContext->setVariableProvider($scopedVariableProvider);
-        /** @phpstan-ignore-next-line  */
         $value = (string)$this->renderChildren();
         // Restore enriched global variables
         $this->renderingContext->setVariableProvider($globalVariableProvider);

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -20,3 +20,9 @@ services:
       - name: 'event.listener'
         identifier: 'deepl-base/process-default-typo3-localization-modes'
         event: WebVision\Deepl\Base\Event\LocalizationProcessPrepareDataHandlerCommandMapEvent
+
+  WebVision\Deepl\Base\EventListener\DefaultTranslationDropdownEventListener:
+    tags:
+      - name: 'event.listener'
+        identifier: 'deepl-base/default-translation'
+        event: WebVision\Deepl\Base\Event\ViewHelpers\ModifyInjectVariablesViewHelperEvent

--- a/Configuration/page.tsconfig
+++ b/Configuration/page.tsconfig
@@ -1,0 +1,3 @@
+# Registration of Fluid backend for TYPO3 v12
+# @see https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/12.0/Feature-96812-OverrideBackendTemplatesWithTSconfig.html
+templates.typo3/cms-backend.1749552370 = web-vision/deepl-base:Resources/Private/Backend/

--- a/README.md
+++ b/README.md
@@ -1,21 +1,21 @@
 # TYPO3 Extension `DeepL Base`
 
-|                  | URL                                                                     |
-|------------------|-------------------------------------------------------------------------|
-| **Repository:**  | https://github.com/fgtclb/academic-bite-jobs                            |
-| **Read online:** | https://docs.typo3.org/p/fgtclb/academic/academic-bite-jobs/main/en-us/ |
-| **TER:**         | https://extensions.typo3.org/extension/academic_bite_jobs/              |
+|                  | URL                                                        |
+|------------------|------------------------------------------------------------|
+| **Repository:**  | https://github.com/web-vision/deepl-base                   |
+| **Read online:** | https://docs.typo3.org/p/web-vision/deepl-base/main/en-us/ |
+| **TER:**         | https://extensions.typo3.org/extension/deepl_base/         |
 
 ## Description
 
 This package is a TYPO Extension providing some shared things required
 by multiple deepl translate or write related extensions, which should
-work together but must working independent of each other requiring this
+work together but must work independent of each other, requiring this
 shared base extension as common ground.
 
 > [!NOTE]
-> This extension does not provide anything use-full as direct usage,
-> and make no sense to install it solo. Should only be a dependency
+> This extension does not provide anything useful as direct usage,
+> and makes no sense to install it standalone. Should only be a dependency
 > for other extensions.
 
 ## Compatibility
@@ -51,8 +51,8 @@ composer config minimum-stability "dev" \
 ## Documentation
 
 > [!NOTE]
-> For the start the documentation for developers and integrators are contained
-> here in the README.md file and will be converted into a rendered documentation
+> For the start, the documentation for developers and integrators is contained
+> here in the README.md file and will be converted into rendered documentation
 > at a later point.
 
 ### PageLayout module localization model - Translation Modes
@@ -84,6 +84,31 @@ changes.
 </html>
 ```
 
+##### Explicit usage from this extension
+
+```xhtml
+<html
+    data-namespace-typo3-fluid="true"
+    xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
+    xmlns:deeplbase="http://typo3.org/ns/WebVision/Deepl/Base/ViewHelpers"
+>
+<deeplbase:injectVariables identifier="languageTranslationDropdown">
+    <f:for each="{translationPartials}" as="translationPartial">
+        <f:render partial="{translationPartial}" arguments="{_all}"/>
+    </f:for>
+</deeplbase:injectVariables>
+</html>
+```
+
+###### What does it do?
+
+This part renders partials registered by an EventListener. With this identifier
+an extension could provide its own translation dropdown for the Backend PageView.
+The extension must be self-aware registering a partial, which is callable by Fluid.
+
+A working example is provided at `Classes/EventListener/DefaultTranslationDropdownEventListener.php`
+and `Resources/Private/Backend/Partials/Translation/DefaultTranslationDropdown.html`.
+
 ##### ModifyInjectVariablesViewHelperEvent
 
 * `getIdentifier(): string`: identifier used within the fluid template and
@@ -101,5 +126,5 @@ changes.
 
 > [!NOTE]
 > Modifed backend templates are listed here describing the modification, for
-> example if one or more [InjectVariableViewhelper](#injectvariablesviewhelper)
-> has been places along with the identifier and use-case.
+> example, if one or more [InjectVariableViewhelper](#injectvariablesviewhelper)
+> has been placed along with the identifier and use-case.

--- a/Resources/Private/Backend/Partials/PageLayout/LanguageColumns.html
+++ b/Resources/Private/Backend/Partials/PageLayout/LanguageColumns.html
@@ -1,0 +1,154 @@
+<html
+    data-namespace-typo3-fluid="true"
+    xmlns:deeplbase="http://typo3.org/ns/WebVision/Deepl/Base/ViewHelpers"
+    xmlns:f="http://typo3.org/ns/TYPO3Fluid/Fluid/ViewHelpers"
+    xmlns:core="http://typo3.org/ns/TYPO3/CMS/Core/ViewHelpers"
+    xmlns:be="http://typo3.org/ns/TYPO3/CMS/Backend/ViewHelpers"
+>
+<f:if condition="{context.newLanguageOptions}">
+    <f:then>
+        <deeplbase:injectVariables identifier="languageTranslationDropdown">
+            <f:if condition="{translationPartials}">
+                <f:then>
+                    <div class="row row-cols-auto align-items-end g-3 mb-3">
+                        <f:for each="{translationPartials}" as="translationPartial">
+                            <f:render partial="{translationPartial}" arguments="{_all}"/>
+                        </f:for>
+                    </div>
+                </f:then>
+            </f:if>
+        </deeplbase:injectVariables>
+    </f:then>
+</f:if>
+
+<f:comment><!-- Identical to EXT:backend/Resources/Partials/PageLayout/LanguageColumns only copied except deepl viewhelper insertion. --></f:comment>
+<div class="t3-grid-container">
+    <table cellpadding="0" cellspacing="0" class="t3-page-columns t3-grid-table t3js-page-columns">
+        <tr>
+            <f:for each="{languageColumns}" as="languageColumn">
+                <td valign="top"
+                    class="t3-page-column t3-page-column-lang-name"
+                    data-language-uid="{languageColumn.context.siteLanguage.languageId}"
+                    data-language-title="{languageColumn.context.siteLanguage.title}"
+                    data-flag-identifier="{languageColumn.context.siteLanguage.flagIdentifier}"
+                >
+                    <h2>{languageColumn.context.siteLanguage.title}</h2>
+                    <f:if condition="{languageColumn.context.languageMode}">
+                        <span class="label label-{languageColumn.context.languageModeLabelClass}">{languageColumn.context.languageMode}</span>
+                    </f:if>
+                </td>
+            </f:for>
+        </tr>
+        <tr>
+            <f:for each="{languageColumns}" as="languageColumn">
+                <td class="t3-page-column t3-page-lang-label nowrap">
+                    <div class="btn-group">
+                        <f:if condition="{languageColumn.allowViewPage}">
+                            <a href="#" class="btn btn-default btn-sm" {languageColumn.previewUrlAttributes -> f:format.raw()} title="{languageColumn.viewPageLinkTitle}">
+                                <core:icon identifier="actions-view" />
+                            </a>
+                        </f:if>
+                        <f:if condition="{languageColumn.allowEditPage}">
+                            <a href="{languageColumn.pageEditUrl}" class="btn btn-default btn-sm" title="{languageColumn.pageEditTitle}">
+                                <core:icon identifier="actions-open" />
+                            </a>
+                        </f:if>
+                        <deeplbase:extensionActive extension="enable_translated_content">
+                            <f:render partial="Button/EnableTranslatedContent" arguments="{_all}"/>
+                        </deeplbase:extensionActive>
+                        <f:if condition="{allowEditContent} && {languageColumn.context.siteLanguage.languageId} && {languageColumn.translationData.untranslatedRecordUids}">
+                            <a
+                                href="#"
+                                class="btn btn-default btn-sm t3js-localize disabled"
+                                title="{languageColumn.context.translatePageTitle}"
+                                data-page="{languageColumn.context.localizedPageRecord.title}"
+                                data-has-elements="{languageColumn.translationData.hasTranslations as integer}"
+                                data-table="tt_content"
+                                data-page-id="{context.pageId}"
+                                data-language-id="{languageColumn.context.siteLanguage.languageId}"
+                                data-language-name="{languageColumn.context.siteLanguage.title}"
+                            >
+                                <core:icon identifier="actions-localize" />
+                                {languageColumn.translatePageTitle}
+                            </a>
+                        </f:if>
+                    </div>
+                    {languageColumn.pageIcon -> f:format.raw()}
+                    {languageColumn.context.localizedPageTitle -> f:format.crop(maxCharacters: maxTitleLength)}
+                </td>
+            </f:for>
+        </tr>
+        <f:if condition="{context.drawingConfiguration.defaultLanguageBinding}">
+            <f:then>
+                <f:variable name="grid" value="{languageColumns.0.grid}" />
+                <f:for each="{context.drawingConfiguration.activeColumns}" as="columnNumber">
+                    <tr>
+                        <f:for each="{languageColumns}" as="languageColumn">
+                            <f:variable name="column" value="{be:languageColumn(languageColumn: languageColumn, columnNumber: columnNumber)}" />
+                            <td data-colpos="{column.columnNumber}" valign="top">
+                                <f:render partial="PageLayout/Grid/ColumnHeader" arguments="{_all}" />
+                            </td>
+                        </f:for>
+                    </tr>
+                    <f:variable name="column" value="{be:languageColumn(languageColumn: languageColumns.0, columnNumber: columnNumber)}" />
+                    <f:for each="{column.items}" as="gridItem" iteration="itemIterator">
+                        <tr>
+                            <td class="t3-grid-cell" valign="top" data-colpos="{column.columnNumber}">
+                                <f:variable name="column" value="{be:languageColumn(languageColumn: languageColumns.0, columnNumber: columnNumber)}" />
+                                <f:variable name="item" value="{gridItem}" />
+                                <f:render partial="PageLayout/Record" arguments="{_all}" />
+                            </td>
+                            <f:for each="{languageColumns}" as="languageColumn">
+                                <f:if condition="{languageColumn.context.siteLanguage.languageId} > 0">
+                                    <f:variable name="column" value="{be:languageColumn(languageColumn: languageColumn, columnNumber: columnNumber)}" />
+                                    <td class="t3-grid-cell" valign="top" data-colpos="{column.columnNumber}">
+                                        <f:variable name="languageId" value="{languageColumn.context.siteLanguage.languageId}" />
+                                        <f:if condition="{languageColumn.translationData.mode} == 'connected'">
+                                            <f:then>
+                                                <f:if condition="{gridItem.translations.{languageId}}">
+                                                    <f:variable name="item" value="{gridItem.translations.{languageId}}" />
+                                                    <f:render partial="PageLayout/Record" arguments="{_all}" />
+                                                </f:if>
+                                            </f:then>
+                                            <f:else>
+                                                <f:if condition="{itemIterator.isFirst}">
+                                                    <f:variable name="languageColumnNonConnected">{languageColumns.{languageId}}</f:variable>
+                                                    <f:variable name="column" value="{be:languageColumn(languageColumn: languageColumnNonConnected, columnNumber: columnNumber)}" />
+                                                    <f:for each="{column.items}" as="item">
+                                                        <f:render partial="PageLayout/Record" arguments="{_all}" />
+                                                    </f:for>
+                                                </f:if>
+                                            </f:else>
+                                        </f:if>
+                                    </td>
+                                </f:if>
+                            </f:for>
+                        </tr>
+                    </f:for>
+                    <tr>
+                        <f:for each="{languageColumns}" as="languageColumn">
+                            <f:variable name="column" value="{be:languageColumn(languageColumn: languageColumn, columnNumber: columnNumber)}" />
+                            <td data-colpos="{column.columnNumber}" valign="top">
+                                <f:format.raw>{column.afterSectionMarkup}</f:format.raw>
+                            </td>
+                        </f:for>
+                    </tr>
+                </f:for>
+            </f:then>
+            <f:else>
+                <f:for each="{context.drawingConfiguration.activeColumns}" as="columnNumber">
+                    <tr>
+                        <f:for each="{languageColumns}" as="languageColumn">
+                            <f:if condition="{languageColumn.grid.columns}">
+                                <f:variable name="grid" value="{languageColumn.grid}" />
+                                <f:variable name="column" value="{be:languageColumn(languageColumn: languageColumn, columnNumber: columnNumber)}" />
+                                <f:render partial="PageLayout/Grid/Column" arguments="{_all}" />
+                            </f:if>
+                        </f:for>
+                    </tr>
+                </f:for>
+            </f:else>
+        </f:if>
+    </table>
+</div>
+</html>

--- a/Resources/Private/Backend/Partials/Translation/DefaultTranslationDropdown.html
+++ b/Resources/Private/Backend/Partials/Translation/DefaultTranslationDropdown.html
@@ -1,0 +1,15 @@
+<html
+    data-namespace-typo3-fluid="true"
+    xmlns:deepl="http://typo3.org/ns/WebVision/Deepltranslate/Core/ViewHelpers"
+    xmlns:f="http://typo3.org/ns/TYPO3Fluid/Fluid/ViewHelpers"
+    xmlns:core="http://typo3.org/ns/TYPO3/CMS/Core/ViewHelpers"
+    xmlns:be="http://typo3.org/ns/TYPO3/CMS/Backend/ViewHelpers"
+>
+<div class="col">
+    <select class="form-select" name="createNewLanguage" data-global-event="change" data-action-navigate="$value">
+        <f:for each="{context.newLanguageOptions}" as="languageName" key="url">
+            <option value="{url}">{languageName}</option>
+        </f:for>
+    </select>
+</div>
+</html>

--- a/Tests/Functional/ViewHelpers/ExtensionActiveViewHelperTest.php
+++ b/Tests/Functional/ViewHelpers/ExtensionActiveViewHelperTest.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WebVision\Deepl\Base\Tests\Functional\ViewHelpers;
+
+use Generator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\Information\Typo3Version;
+use TYPO3\CMS\Fluid\Core\Rendering\RenderingContextFactory;
+use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
+use TYPO3Fluid\Fluid\Core\Cache\FluidCacheInterface;
+use TYPO3Fluid\Fluid\Core\Cache\SimpleFileCache;
+use TYPO3Fluid\Fluid\Core\Rendering\RenderingContext;
+use TYPO3Fluid\Fluid\View\TemplateView;
+
+final class ExtensionActiveViewHelperTest extends FunctionalTestCase
+{
+    protected bool $initializeDatabase = false;
+
+    protected array $testExtensionsToLoad = [
+        'web-vision/deepl-base',
+    ];
+
+    protected static FluidCacheInterface $cache;
+
+    /**
+     *  Absolute path to cache directory
+     */
+    protected static string $cachePath;
+
+    public static function setUpBeforeClass(): void
+    {
+        self::$cachePath = sys_get_temp_dir() . '/' . 'fluid-functional-tests-' . sha1(__CLASS__);
+        mkdir(self::$cachePath);
+        self::$cache = (new SimpleFileCache(self::$cachePath));
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        self::$cache->flush();
+        rmdir(self::$cachePath);
+    }
+
+    protected function setUp(): void
+    {
+        if ((new Typo3Version())->getMajorVersion() >= 13) {
+            $this->coreExtensionsToLoad[] = 'typo3/cms-install';
+        }
+        parent::setUp();
+    }
+
+    /**
+     * @return Generator<string, array{template: string, variables: array<string, mixed>, expected: string}>
+     */
+    public static function renderDataProvider(): Generator
+    {
+        yield 'extension name empty, await else' => [
+            'template' => '<deeplbase:extensionActive extension="" then="thenArgument" else="elseArgument" />',
+            'variables' => [],
+            'expected' => 'elseArgument',
+        ];
+        yield 'extension set to own, await then' => [
+            'template' => '<deeplbase:extensionActive extension="deepl_base" then="thenArgument" else="elseArgument" />',
+            'variables' => [],
+            'expected' => 'thenArgument',
+        ];
+
+        yield 'extension set to non existent, await else' => [
+            'template' => '<deeplbase:extensionActive extension="non_existent" then="thenArgument" else="elseArgument" />',
+            'variables' => [],
+            'expected' => 'elseArgument',
+        ];
+
+        yield 'extension provided as undefined fluid variable placeholder, await else' => [
+            'template' => '<deeplbase:extensionActive extension="{someUndefinedVariable}" then="thenArgument" else="elseArgument" />',
+            'variables' => [],
+            'expected' => 'elseArgument',
+        ];
+    }
+
+    /**
+     * @param array<string, mixed> $variables
+     */
+    #[DataProvider('renderDataProvider')]
+    #[Test]
+    public function render(string $template, array $variables, string $expected): void
+    {
+        /** @var RenderingContext $context */
+        $context = $this->get(RenderingContextFactory::class)->create();
+        $context->getViewHelperResolver()->addNamespace('deeplbase', 'WebVision\\Deepl\\Base\\ViewHelpers');
+        $context->setCache(self::$cache);
+        $context->getTemplatePaths()->setTemplateSource($template);
+        foreach ($variables as $key => $value) {
+            $context->getVariableProvider()->add($key, $value);
+        }
+        $this->assertSame($expected, (new TemplateView($context))->render());
+    }
+}


### PR DESCRIPTION
With the new ViewHelper introduced a rendering of the output inside the ViewHelper was added. This requires the ViewHelper itself having a non-escaped output to allow HTML being rendered 'as-is' instead of being escaped.

This Pull request adds the template overrides for TYPO3 `backend` enabling other extensions manipulation of the translation dropdowns.
As a preparation for future releases and features, the TYPO3 Core translation dropdown is registered as a separate EventListener inside the `deepl_base` extension.

According to the non-DeepL-related extension `enable_translate_content` it is necessary to move the ViewHelper `deeplbase:extensionEnabled` from `deepltranslate_core` to `deepl_base`.
This allows installation and usage of  `deepl_write` together with `enable_translated_content`.