### PR TITLE
[BUGFIX] Make copy mode work again

### DIFF
--- a/Classes/EventListener/ProvideDefaultTypo3LocalizationModesEventListener.php
+++ b/Classes/EventListener/ProvideDefaultTypo3LocalizationModesEventListener.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace WebVision\Deepl\Base\EventListener;
 
+use TYPO3\CMS\Backend\Controller\Page\LocalizationController;
 use TYPO3\CMS\Core\Utility\MathUtility;
 use WebVision\Deepl\Base\Event\GetLocalizationModesEvent;
 use WebVision\Deepl\Base\Localization\LocalizationMode;
@@ -24,22 +25,22 @@ final class ProvideDefaultTypo3LocalizationModesEventListener
         $modes = [];
         if ($this->allowTranslate($event)) {
             $modes[] = new LocalizationMode(
-                identifier: 'localize',
+                identifier: LocalizationController::ACTION_LOCALIZE,
                 title: $event->getLanguageService()->sL('LLL:EXT:backend/Resources/Private/Language/locallang_layout.xlf:localize.wizard.button.translate'),
                 description: $event->getLanguageService()->sL('LLL:EXT:backend/Resources/Private/Language/locallang_layout.xlf:localize.educate.translate'),
                 icon: 'actions-localize',
-                before: ['copy'],
+                before: [LocalizationController::ACTION_COPY],
                 after: [],
             );
         }
         if ($this->allowCopy($event)) {
             $modes[] = new LocalizationMode(
-                identifier: 'copy',
+                identifier: LocalizationController::ACTION_COPY,
                 title: $event->getLanguageService()->sL('LLL:EXT:backend/Resources/Private/Language/locallang_layout.xlf:localize.wizard.button.copy'),
                 description: $event->getLanguageService()->sL('LLL:EXT:backend/Resources/Private/Language/locallang_layout.xlf:localize.educate.copy'),
                 icon: 'actions-edit-copy',
                 before: [],
-                after: ['localize'],
+                after: [LocalizationController::ACTION_LOCALIZE],
             );
         }
 

--- a/Tests/Functional/Controller/Backend/Fixtures/TranslationModes/Result/copyToLanguage.csv
+++ b/Tests/Functional/Controller/Backend/Fixtures/TranslationModes/Result/copyToLanguage.csv
@@ -1,0 +1,4 @@
+"tt_content",
+,"uid","pid","CType","sys_language_uid","header","l18n_parent","l10n_source"
+,1,3,"header",0,"Content header",0,0
+,2,3,"header",1,"[Translate to Deutsch:] Content header",0,1

--- a/Tests/Functional/Controller/Backend/Fixtures/TranslationModes/Result/localize.csv
+++ b/Tests/Functional/Controller/Backend/Fixtures/TranslationModes/Result/localize.csv
@@ -1,0 +1,4 @@
+"tt_content",
+,"uid","pid","CType","sys_language_uid","header","l18n_parent","l10n_source"
+,1,3,"header",0,"Content header",0,0
+,2,3,"header",1,"[Translate to Deutsch:] Content header",1,1

--- a/Tests/Functional/Controller/Backend/Fixtures/TranslationModes/TranslationModeSetup.csv
+++ b/Tests/Functional/Controller/Backend/Fixtures/TranslationModes/TranslationModeSetup.csv
@@ -1,0 +1,13 @@
+"pages",
+,"uid","pid","doktype","sys_language_uid","l10n_parent","slug","title","TSconfig",
+,1,0,1,0,0,"/","site 1","",
+,2,0,1,1,1,"/","Seite 1","",
+,3,1,1,0,0,"/home","Home","",
+,4,1,1,1,3,"/start","Start","",
+"tt_content",
+,"uid","pid","CType","sys_language_uid","header"
+,1,3,"header",0,"Content header"
+"be_users",
+,"uid","pid","tstamp","username","password","admin","disable","starttime","endtime","options","crdate","workspace_perms","deleted","TSconfig","lastlogin","workspace_id"
+# The password is "password"
+,1,0,1366642540,"admin","$1$tCrlLajZ$C0sikFQQ3SWaFAZ1Me0Z/1",1,0,0,0,0,1366642540,1,0,,1371033743,0


### PR DESCRIPTION
The newly added structure with LocalizationModes registered as configurable modes through PHP instead of the hard-coded Localization used the `LocalizationController::ACTION_*` constants for detecting the EventListener being responsible for a translation mode.

As the JavaScript identifier was taken for the comparison and the identifier was named `copy`, but the compare-to is named `copyFromLanguage`, the condition skipped the EventListener instead of building the command map for the DataHandler to work.

Fixes #11