### PR TITLE
[BUGFIX] Use correct namespace in `ext_emconf.php`

### DIFF
--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -23,7 +23,7 @@ $EM_CONF[$_EXTKEY] = [
     ],
     'autoload' => [
         'psr-4' => [
-            'WebVision\\Deepltranslate\\Core\\' => 'Classes',
+            'WebVision\\Deepl\\Base\\' => 'Classes',
         ],
     ],
 ];


### PR DESCRIPTION
`ext_emconf.php` contains the php autoloading definition
for class mode instances which should be obsolete nower
days but kept until final investigated.

Due to `copy&pasta` error when creating this extension,
the wrong namespace has been left in `ext_emconf.php`,
which is now corrected.
