### PR TITLE
[WIP][FEATURE] Make DeepL translation TSconfig configurable

### DIFF
--- a/Resources/Private/Backend/Templates/RecordList.html
+++ b/Resources/Private/Backend/Templates/RecordList.html
@@ -1,0 +1,56 @@
+<html
+    xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
+    xmlns:deeplbase="http://typo3.org/ns/WebVision/Deepl/Base/ViewHelpers"
+    data-namespace-typo3-fluid="true"
+>
+
+<f:layout name="Module" />
+
+<f:section name="Before">
+    <f:asset.module identifier="@typo3/backend/recordlist.js"/>
+    <f:asset.module identifier="@typo3/backend/record-download-button.js"/>
+    <f:asset.module identifier="@typo3/backend/clear-cache.js"/>
+    <f:asset.module identifier="@typo3/backend/record-search.js"/>
+    <f:asset.module identifier="@typo3/backend/ajax-data-handler.js"/>
+    <f:asset.module identifier="@typo3/backend/column-selector-button.js"/>
+    <f:asset.module identifier="@typo3/backend/multi-record-selection.js"/>
+    <f:asset.module identifier="@typo3/backend/multi-record-selection-delete-action.js"/>
+    <f:asset.module identifier="@typo3/backend/clipboard-panel.js"/>
+    <f:asset.module identifier="@typo3/backend/new-content-element-wizard-button.js"/>
+    <f:asset.module identifier="@typo3/backend/element/immediate-action-element.js"/>
+    <f:asset.module identifier="@typo3/backend/context-menu.js"/>
+    <f:asset.module identifier="@typo3/backend/element/editable-page-title.js"/>
+    <f:be.pageRenderer
+        addJsInlineLabels="{
+            'editablePageTitle.input.field.label': 'LLL:EXT:backend/Resources/Private/Language/locallang_layout.xlf:editPageTitle.input.field.label',
+            'editablePageTitle.button.edit.label': 'LLL:EXT:backend/Resources/Private/Language/locallang_layout.xlf:editPageTitle',
+            'editablePageTitle.button.save.label': 'LLL:EXT:core/Resources/Private/Language/locallang_common.xlf:save',
+            'editablePageTitle.button.cancel.label': 'LLL:EXT:core/Resources/Private/Language/locallang_common.xlf:cancel'
+        }"
+    />
+    <f:variable name="immediateActionArgs" value="{0: 'web', 1: pageId}" />
+    <typo3-immediate-action
+        action="TYPO3.Backend.Storage.ModuleStateStorage.update"
+        args="{immediateActionArgs -> f:format.json() -> f:format.htmlspecialchars()}"
+    ></typo3-immediate-action>
+</f:section>
+
+<f:section name="Content">
+    <deeplbase:injectVariables identifier="core-template-recordlist"/>
+    <typo3-backend-editable-page-title
+        pageTitle="{pageTitle}"
+        pageId="{pageId}"
+        {isPageEditable ? 'editable' : ''}
+    >
+        {pageTitle}
+    </typo3-backend-editable-page-title>
+    <f:format.raw>{additionalContentTop}</f:format.raw>
+    <f:format.raw>{languageSelectorHtml}</f:format.raw>
+    <f:format.raw>{searchBoxHtml}</f:format.raw>
+    <f:format.raw>{pageTranslationsHtml}</f:format.raw>
+    <f:format.raw>{tableListHtml}</f:format.raw>
+    <f:format.raw>{clipboardHtml}</f:format.raw>
+    <f:format.raw>{additionalContentBottom}</f:format.raw>
+</f:section>
+
+</html>


### PR DESCRIPTION
Following the example of TYPO3's Page TSConfig settings, DeepL should also allow settings to be made via Page TSConfig. This makes it easier for integrators to use and provides a better overview, as the settings are made in the same way as for TYPO3 Core.

New:

```
mod {
    web_layout {
        localization {
            # default, set to 0 to disable DeepL Translate
            enableDeeplTranslate = 1
            # default, set to 1 to disable core translation options
            disableCoreTranslation = 0
        }
    }
}
```