### PR TITLE
[!!!][TASK] DPL-158: Move v13 only classes into dedicated namespace

### DIFF
--- a/Build/phpstan/Core14/phpstan.neon
+++ b/Build/phpstan/Core14/phpstan.neon
@@ -22,10 +22,6 @@ parameters:
     # excluded - TYPO3 v13 only
     - ../../../Classes/Event/LocalizationProcessPrepareDataHandlerCommandMapEvent.php
     # excluded - TYPO3 v13 only
-    - ../../../Classes/EventListener/PrepareLocalizationProcessDataHandlerCommandMapForTypo3LocalizationModes.php
-    # excluded - TYPO3 v13 only
-    - ../../../Classes/EventListener/ProvideDefaultTypo3LocalizationModesEventListener.php
-    # excluded - TYPO3 v13 only
     - ../../../Tests/Functional/Core13/Controller/Backend/LocalizationControllerTest.php
     # excluded - needs to be fixed for TYPO3 v14 due to fluid changes but not used currently - delayed
     - ../../../Classes/ViewHelpers/InjectVariablesViewHelper.php

--- a/CHANGELOG/2.0/BREAKING-SeparatedProvidedFeaturesBasedOnTYPO3Version.md
+++ b/CHANGELOG/2.0/BREAKING-SeparatedProvidedFeaturesBasedOnTYPO3Version.md
@@ -10,14 +10,22 @@ Following class(s) has been moved to a new namespace:
 * `\WebVision\Deepl\Base\Controller\Backend\LocalizationController` to
   `\WebVision\Deepl\Base\Core13\Controller\Backend\LocalizationController`
 
+* `\WebVision\Deepl\Base\EventListener\DefaultTranslationDropdownEventListener`
+  to `\WebVision\Deepl\Base\Core13\EventListener\DefaultTranslationDropdownEventListener`
+
+* `\WebVision\Deepl\Base\EventListener\PrepareLocalizationProcessDataHandlerCommandMapForTypo3LocalizationModes`
+  to `\WebVision\Deepl\Base\Core13\EventListener\PrepareLocalizationProcessDataHandlerCommandMapForTypo3LocalizationModes`
+
+* `\WebVision\Deepl\Base\EventListener\ProvideDefaultTypo3LocalizationModesEventListener`
+  to `\WebVision\Deepl\Base\Core13\EventListener\ProvideDefaultTypo3LocalizationModesEventListener`
+
 Following classes has been marked as deprecated and are not used in TYPO3 v14
-albeit being available and kept to minimize fatal breaking errors:
+albeit being available and kept to minimize fatal breaking errors and reduce
+required adoption in packages using `EXT:deepl_base`:
 
 * `\WebVision\Deepl\Base\Event\GetLocalizationModesEvent`
 * `\WebVision\Deepl\Base\Event\LocalizationProcessPrepareDataHandlerCommandMapEvent`
-* `\WebVision\Deepl\Base\EventListener\DefaultTranslationDropdownEventListener`
-* `\WebVision\Deepl\Base\EventListener\PrepareLocalizationProcessDataHandlerCommandMapForTypo3LocalizationModes`
-* `\WebVision\Deepl\Base\EventListener\ProvideDefaultTypo3LocalizationModesEventListener`
+
 
 Further, backend template overrides has been moved into a dedicated folder
 and related PageTsConfig option has been adjusted and nested into a condition

--- a/Core13/Classes/EventListener/DefaultTranslationDropdownEventListener.php
+++ b/Core13/Classes/EventListener/DefaultTranslationDropdownEventListener.php
@@ -2,10 +2,9 @@
 
 declare(strict_types=1);
 
-namespace WebVision\Deepl\Base\EventListener;
+namespace WebVision\Deepl\Base\Core13\EventListener;
 
 use TYPO3\CMS\Core\Attribute\AsEventListener;
-use TYPO3\CMS\Core\Information\Typo3Version;
 use WebVision\Deepl\Base\Event\ViewHelpers\ModifyInjectVariablesViewHelperEvent;
 
 /**
@@ -21,10 +20,8 @@ final class DefaultTranslationDropdownEventListener
     )]
     public function __invoke(ModifyInjectVariablesViewHelperEvent $event): void
     {
-        if ((new Typo3Version())->getMajorVersion() > 13) {
-            // Not needed in TYPO v14 or newer.
-            return;
-        }
+        // Note that this identifier / ViewHelper is only included in TYPO3 v13
+        // backend template overrides and therefore restricts this already down.
         if ($event->getIdentifier() !== 'languageTranslationDropdown') {
             return;
         }

--- a/Core13/Classes/EventListener/PrepareLocalizationProcessDataHandlerCommandMapForTypo3LocalizationModes.php
+++ b/Core13/Classes/EventListener/PrepareLocalizationProcessDataHandlerCommandMapForTypo3LocalizationModes.php
@@ -2,11 +2,10 @@
 
 declare(strict_types=1);
 
-namespace WebVision\Deepl\Base\EventListener;
+namespace WebVision\Deepl\Base\Core13\EventListener;
 
 use TYPO3\CMS\Backend\Controller\Page\LocalizationController;
 use TYPO3\CMS\Core\Attribute\AsEventListener;
-use TYPO3\CMS\Core\Information\Typo3Version;
 use WebVision\Deepl\Base\Event\LocalizationProcessPrepareDataHandlerCommandMapEvent;
 
 /**
@@ -24,10 +23,6 @@ final class PrepareLocalizationProcessDataHandlerCommandMapForTypo3LocalizationM
     )]
     public function __invoke(LocalizationProcessPrepareDataHandlerCommandMapEvent $event): void
     {
-        if ((new Typo3Version())->getMajorVersion() > 13) {
-            // Not needed in TYPO v14 or newer.
-            return;
-        }
         if (!in_array($event->getLocalizationMode()->identifier, [LocalizationController::ACTION_COPY, LocalizationController::ACTION_LOCALIZE], true)) {
             // Not responsible, early return.
             return;

--- a/Core13/Classes/EventListener/ProvideDefaultTypo3LocalizationModesEventListener.php
+++ b/Core13/Classes/EventListener/ProvideDefaultTypo3LocalizationModesEventListener.php
@@ -2,11 +2,10 @@
 
 declare(strict_types=1);
 
-namespace WebVision\Deepl\Base\EventListener;
+namespace WebVision\Deepl\Base\Core13\EventListener;
 
 use TYPO3\CMS\Backend\Controller\Page\LocalizationController;
 use TYPO3\CMS\Core\Attribute\AsEventListener;
-use TYPO3\CMS\Core\Information\Typo3Version;
 use TYPO3\CMS\Core\Utility\MathUtility;
 use WebVision\Deepl\Base\Event\GetLocalizationModesEvent;
 use WebVision\Deepl\Base\Localization\LocalizationMode;
@@ -29,10 +28,6 @@ final class ProvideDefaultTypo3LocalizationModesEventListener
     )]
     public function __invoke(GetLocalizationModesEvent $event): void
     {
-        if ((new Typo3Version())->getMajorVersion() > 13) {
-            // Not needed in TYPO v14 or newer.
-            return;
-        }
         $modes = [];
         if ($this->allowTranslate($event)) {
             $modes[] = new LocalizationMode(


### PR DESCRIPTION
TYPO3 v13 only classes are moved to a dedicated namespace to cleanup
the extension structure and make removal easier with the next major
version dropping TYPO3 v13 support.

Following classes are moved into dedicated TYPO3 v13 only namespace
and deprecated in the same step:

* `\WebVision\Deepl\Base\EventListener\DefaultTranslationDropdownEventListener`
  to `\WebVision\Deepl\Base\Core13\EventListener\DefaultTranslationDropdownEventListener`

* `\WebVision\Deepl\Base\EventListener\PrepareLocalizationProcessDataHandlerCommandMapForTypo3LocalizationModes`
  to `\WebVision\Deepl\Base\Core13\EventListener\PrepareLocalizationProcessDataHandlerCommandMapForTypo3LocalizationModes`

* `\WebVision\Deepl\Base\EventListener\ProvideDefaultTypo3LocalizationModesEventListener`
  to `\WebVision\Deepl\Base\Core13\EventListener\ProvideDefaultTypo3LocalizationModesEventListener`
  
TYPO3 v13 only excludes for TYPO3 v14 phpstan execution
is now removed.
