### PR TITLE
[TASK] DPL-158: Mitigate `ext_emconf.php` deprecation in functional tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -58,7 +58,11 @@
     "extra": {
         "typo3/cms": {
             "extension-key": "deepl_base",
-            "web-dir": ".Build/Web"
+            "web-dir": ".Build/Web",
+            "Package": {
+                "providesPackages": []
+            },
+            "version": "2.0.0"
         },
         "branch-alias": {
             "dev-main": "2.0.x-dev"

--- a/patches/typo3-cms-backend_93484_bugfix-strip-title-from-package-description-if-extracted.patch
+++ b/patches/typo3-cms-backend_93484_bugfix-strip-title-from-package-description-if-extracted.patch
@@ -1,0 +1,43 @@
+@package typo3/cms-backend
+@label [BUGFIX] Strip title from package description if extracted
+@link https://review.typo3.org/c/Packages/TYPO3.CMS/+/93484
+@version ~14.2.0
+
+From 17f8256acba6eb1c5b4b3e2732b63dc891279ad0 Mon Sep 17 00:00:00 2001
+From: Benjamin Kott <benjamin.kott@outlook.com>
+Date: Tue, 31 Mar 2026 11:24:01 +0200
+Subject: [PATCH] [BUGFIX] Strip title from package description if extracted
+
+When a composer description contains " - ", the part before
+the separator is used as the package title. However, the
+description was not updated and still contained the full
+string including the title prefix, leading to duplicate
+information when both title and description are displayed.
+
+The description is now set to only the part after the
+separator when a title is extracted.
+
+Resolves: #109435
+Releases: main
+Change-Id: I2a7a57ca18b750fa26fc967fe3cc5f6df07f3728
+Reviewed-on: https://review.typo3.org/c/Packages/TYPO3.CMS/+/93484
+Reviewed-by: Benjamin Franzke <ben@bnf.dev>
+Reviewed-by: Benni Mack <benni@typo3.org>
+Tested-by: Benjamin Franzke <ben@bnf.dev>
+Tested-by: Benni Mack <benni@typo3.org>
+Tested-by: core-ci <typo3@b13.com>
+---
+
+diff --git a/Classes/Controller/AboutController.php b/Classes/Controller/AboutController.php
+index 7ffdf16..c8ca11c 100644
+--- a/Classes/Controller/AboutController.php
++++ b/Classes/Controller/AboutController.php
+@@ -81,7 +81,7 @@
+             }
+             $extensions[] = [
+                 'key' => $package->getPackageKey(),
+-                'title' => $package->getPackageMetaData()->getDescription(),
++                'title' => $package->getPackageMetaData()->getTitle(),
+                 'authors' => $package->getValueFromComposerManifest('authors'),
+             ];
+         }

--- a/patches/typo3-cms-core_93484_bugfix-strip-title-from-package-description-if-extracted.patch
+++ b/patches/typo3-cms-core_93484_bugfix-strip-title-from-package-description-if-extracted.patch
@@ -1,0 +1,53 @@
+@package typo3/cms-core
+@label [BUGFIX] Strip title from package description if extracted
+@link https://review.typo3.org/c/Packages/TYPO3.CMS/+/93484
+@version ~14.2.0
+@after patches/typo3-cms-core_93530_bugfix-avoid-undefined-property_-stdclass__version-warning.patch
+
+From 17f8256acba6eb1c5b4b3e2732b63dc891279ad0 Mon Sep 17 00:00:00 2001
+From: Benjamin Kott <benjamin.kott@outlook.com>
+Date: Tue, 31 Mar 2026 11:24:01 +0200
+Subject: [PATCH] [BUGFIX] Strip title from package description if extracted
+
+When a composer description contains " - ", the part before
+the separator is used as the package title. However, the
+description was not updated and still contained the full
+string including the title prefix, leading to duplicate
+information when both title and description are displayed.
+
+The description is now set to only the part after the
+separator when a title is extracted.
+
+Resolves: #109435
+Releases: main
+Change-Id: I2a7a57ca18b750fa26fc967fe3cc5f6df07f3728
+Reviewed-on: https://review.typo3.org/c/Packages/TYPO3.CMS/+/93484
+Reviewed-by: Benjamin Franzke <ben@bnf.dev>
+Reviewed-by: Benni Mack <benni@typo3.org>
+Tested-by: Benjamin Franzke <ben@bnf.dev>
+Tested-by: Benni Mack <benni@typo3.org>
+Tested-by: core-ci <typo3@b13.com>
+---
+
+diff --git a/Classes/Package/Package.php b/Classes/Package/Package.php
+index b163b85..383c126 100644
+--- a/Classes/Package/Package.php
++++ b/Classes/Package/Package.php
+@@ -143,13 +143,15 @@
+     {
+         $this->packageMetaData = new MetaData($this->getPackageKey());
+         $description = (string)$this->getValueFromComposerManifest('description');
+-        $this->packageMetaData->setDescription($description);
+         $descriptionParts = explode(' - ', $description, 2);
+-        $title = $description;
+         if (count($descriptionParts) === 2) {
+             $title = $descriptionParts[0];
++            $description = $descriptionParts[1];
++        } else {
++            $title = $description;
+         }
+         $this->packageMetaData->setTitle($title);
++        $this->packageMetaData->setDescription($description);
+         $this->packageMetaData->setPackageType((string)$this->getValueFromComposerManifest('type'));
+         $isFrameworkPackage = $this->packageMetaData->isFrameworkType();
+         $version = (string)($this->getValueFromComposerManifest('version') ?? '1.0.0');

--- a/patches/typo3-cms-core_93530_bugfix-avoid-undefined-property_-stdclass__version-warning.patch
+++ b/patches/typo3-cms-core_93530_bugfix-avoid-undefined-property_-stdclass__version-warning.patch
@@ -1,7 +1,7 @@
 @package typo3/cms-core
 @label [BUGFIX] Avoid `Undefined property: stdClass::$version` warning
 @link https://review.typo3.org/c/Packages/TYPO3.CMS/+/93530
-@version 14.2.0
+@version ~14.2.0
 
 From 0672a9436796d0b8cc047fe29e611a654dbea6e7 Mon Sep 17 00:00:00 2001
 From: Stefan Bürk <stefan@buerk.tech>

--- a/patches/typo3-cms-core_93536_task-allow-extension-version-declaration-in-extra.version.patch
+++ b/patches/typo3-cms-core_93536_task-allow-extension-version-declaration-in-extra.version.patch
@@ -1,0 +1,223 @@
+@package typo3/cms-core
+@label [TASK] Allow extension version declaration in extra.version
+@link https://review.typo3.org/c/Packages/TYPO3.CMS/+/93536
+@version ~14.2.0
+@after patches/typo3-cms-core_93484_bugfix-strip-title-from-package-description-if-extracted.patch
+
+From dcee72fe2e0ffb097d570d626e69c201ad05d403 Mon Sep 17 00:00:00 2001
+From: Helmut Hummel <typo3@helhum.io>
+Date: Fri, 03 Apr 2026 12:08:32 +0200
+Subject: [PATCH] [TASK] Allow extension version declaration in extra.version
+
+For everyone who has a strict requirement to not declare
+the version in the dedicated version field Composer introduced,
+it is now possible to declare the version in extra section.
+
+This field must still match the composer version that is tagged,
+so there is no immediate benefit in doing so except that
+`composer validate --strict` passes.
+
+Releases: main
+Resolves: #109482
+Change-Id: I96cbdb175dc46ff5b3b1f863663412395fd4469c
+---
+
+diff --git a/Classes/Package/Package.php b/Classes/Package/Package.php
+index 383c126..fb31f15 100644
+--- a/Classes/Package/Package.php
++++ b/Classes/Package/Package.php
+@@ -150,16 +150,17 @@
+         } else {
+             $title = $description;
+         }
++        $manifest = $this->getValueFromComposerManifest();
+         $this->packageMetaData->setTitle($title);
+         $this->packageMetaData->setDescription($description);
+-        $this->packageMetaData->setPackageType((string)$this->getValueFromComposerManifest('type'));
++        $this->packageMetaData->setPackageType($manifest->type ?? '');
+         $isFrameworkPackage = $this->packageMetaData->isFrameworkType();
+-        $version = (string)($this->getValueFromComposerManifest('version') ?? '1.0.0');
++        $version = $manifest->version ?? $manifest->extra->{'typo3/cms'}->{'version'} ?? '1.0.0';
+         if ($isFrameworkPackage) {
+             $version = str_replace('-dev', '', (new Typo3Version())->getVersion());
+         }
+         $this->packageMetaData->setVersion($version);
+-        $requirements = $this->getValueFromComposerManifest('require');
++        $requirements = $manifest->require ?? null;
+         if ($requirements !== null) {
+             foreach ($requirements as $packageName => $versionConstraints) {
+                 if ($this->ignoreDependencyInPackageConstraint($packageName, $packageManager, $isBuildingPackageArtifact)) {
+@@ -174,7 +175,7 @@
+                 );
+             }
+         }
+-        $suggestions = $this->getValueFromComposerManifest('suggest');
++        $suggestions = $manifest->suggest ?? null;
+         if ($suggestions !== null) {
+             foreach ($suggestions as $packageName => $description) {
+                 if ($this->ignoreDependencyInPackageConstraint($packageName, $packageManager, $isBuildingPackageArtifact)) {
+@@ -184,7 +185,7 @@
+                 $this->packageMetaData->addConstraint($constraint);
+             }
+         }
+-        $conflicts = $this->getValueFromComposerManifest('conflict');
++        $conflicts = $manifest->conflict ?? null;
+         if ($conflicts !== null) {
+             foreach ($conflicts as $packageName => $versionConstraints) {
+                 if ($this->ignoreDependencyInPackageConstraint($packageName, $packageManager, $isBuildingPackageArtifact)) {
+diff --git a/Classes/Package/PackageManager.php b/Classes/Package/PackageManager.php
+index dd9b427..cc419ff 100644
+--- a/Classes/Package/PackageManager.php
++++ b/Classes/Package/PackageManager.php
+@@ -936,7 +936,10 @@
+     private function isComposerOnlyCapable(\stdClass $manifest): bool
+     {
+         return isset($manifest->extra->{'typo3/cms'}->Package->providesPackages)
+-            && ($manifest->version ?? null) !== null;
++            && (
++                ($manifest->version ?? null) !== null
++                || isset($manifest->extra->{'typo3/cms'}->version)
++            );
+     }
+
+     /**
+diff --git a/Documentation/Changelog/14.2/Deprecation-108345-Deprecation-of-ext-emconf-php.rst b/Documentation/Changelog/14.2/Deprecation-108345-Deprecation-of-ext-emconf-php.rst
+index cea425f..ac98cb6 100644
+--- a/Documentation/Changelog/14.2/Deprecation-108345-Deprecation-of-ext-emconf-php.rst
++++ b/Documentation/Changelog/14.2/Deprecation-108345-Deprecation-of-ext-emconf-php.rst
+@@ -69,9 +69,17 @@
+
+ For compatibility with TYPO3 classic mode, third-party extensions
+ must set the exact extension version in the top-level `"version"` field
+-of `composer.json`. This version should match the version previously
++of `composer.json`. This version must match the version previously
+ defined in `ext_emconf.php` and the released Git tag.
+
++Fixture extensions used in tests can set any version number, for example `1.0.0`,
++but a version number must still be provided to avoid deprecation messages.
++During testing, the version number is not evaluated.
++
++TYPO3 Core extensions may omit the version number
++in `composer.json`, because their version can and will be derived from
++php`\TYPO3\CMS\Core\Information\Typo3Version`.
++
+ If an extension depends on regular Composer packages, these packages
+ must be declared in
+ `extra.typo3/cms.Package.providesPackages`.
+@@ -81,6 +89,14 @@
+ to avoid deprecation messages and to declare future compatibility
+ with TYPO3 classic mode.
+
++If strict `composer.json` validation is required and it errors if the `version` field is set,
++it is also possible to set the version via `extra.typo3/cms.version`.
++
++There is no other benefit to providing the version number in
++`extra.typo3/cms.version`. In fact, it hides mistakes when updating
++the version. It is therefore still recommended to use the `version` field
++provided and evaluated by Composer.
++
+ Impact
+ ======
+
+@@ -109,6 +125,6 @@
+ For the time being, `ext_emconf.php` may still need to be kept for
+ third-party tooling such as TYPO3 TER or Tailor. However, once the
+ required metadata is correctly defined in `composer.json`,
+-TYPO3 will no longer need to evaluate `ext_emconf.php`.
++TYPO3 will no longer evaluate `ext_emconf.php`.
+
+ .. index:: ext:core, NotScanned
+diff --git a/Documentation/Changelog/14.2/Feature-108345-No-ext-em-conf-in-classic-mode.rst b/Documentation/Changelog/14.2/Feature-108345-No-ext-em-conf-in-classic-mode.rst
+index 9a05b80..7bc5f47 100644
+--- a/Documentation/Changelog/14.2/Feature-108345-No-ext-em-conf-in-classic-mode.rst
++++ b/Documentation/Changelog/14.2/Feature-108345-No-ext-em-conf-in-classic-mode.rst
+@@ -18,7 +18,7 @@
+
+ This is now resolved by allowing an extension's `composer.json`
+ to contain information that previously had to be defined in
+-`ext_emconf.php`.
++`ext_emconf.php`:
+
+ 1. Extension title
+ 2. Extension version
+@@ -30,12 +30,12 @@
+ See :ref:`feature-108653-1767199420` for how the extension title can also be set
+ in `composer.json`.
+
+-The version number can be set in the regular `"version"` field
+-in `composer.json`.
+-
+ Extension version
+ -----------------
+
++The version number can be set in the regular `"version"` field
++in `composer.json`.
++
+ For third-party extensions to be compatible with TYPO3 classic mode,
+ this field must now be set to the exact version previously defined in `ext_emconf.php`
+ and must match the version in the Git tag
+@@ -57,7 +57,7 @@
+ a version range.
+
+ `composer.json` also contains a field for specifying dependencies
+-by using a Composer package name with a version range.
++using a Composer package name with a version range.
+ However, there is no direct way to distinguish whether such a package name
+ refers to another TYPO3 extension or to a regular Composer package
+ that should be installed from Packagist.
+@@ -167,13 +167,45 @@
+         }
+     }
+
++If strict `composer.json` validation is required and it errors if the `version` field is set,
++it is also possible to set the version via `extra.typo3/cms.version`:
++
++..  code-block:: json
++
++    {
++        "name": "vendor/example",
++        "type": "typo3-cms-extension",
++        "description": "example",
++        "license": "GPL-2.0-or-later",
++        "require": {
++            "typo3/cms-core": "^14.2",
++            "vendor/other-example": "*",
++            "symfony/dotenv": "^8.0"
++        },
++        "extra": {
++            "typo3/cms": {
++                "extension-key": "example_extension",
++                "version": "1.0.0",
++                "Package": {
++                    "providesPackages": {
++                        "symfony/dotenv": ""
++                    }
++                }
++            }
++        }
++    }
++
++There is no other benefit to providing the version number in `extra.typo3/cms.version`.
++In fact, it hides mistakes when updating the version. It is therefore still recommended
++to use the `version` field provided and evaluated by Composer.
++
+ Be aware that keeping `ext_emconf.php`, while no longer directly required
+ by TYPO3, may still be necessary for some tools,
+ such as Tailor or TYPO3 TER. Therefore, for the time being, it is recommended
+ to keep the file and ensure that its information stays in sync
+ with `composer.json` as outlined above.
+
+-However, TYPO3 will **not** evaluate `ext_emconf.php` any more if the `version` field
++However, TYPO3 will **not** evaluate `ext_emconf.php` anymore if the `version` field
+ and `providesPackages` are correctly defined in `composer.json`.
+
+ Impact
+@@ -181,7 +213,7 @@
+
+ Extensions can now omit `ext_emconf.php` in TYPO3 classic mode.
+ A deprecation message is shown during cache warm-up when `ext_emconf.php`
+-is present and `composer.json` is not yet future-proof,
++is present and `composer.json` is not yet future-proof
+ because it does not contain the `version` and `providesPackages` definitions.
+
+ .. index:: ext:core


### PR DESCRIPTION
This change adds a new composer patch for a pending change in the TYPO3
Core, which is one of the possible solution discussed to mitigate the
`version` topic for classic mode installations, functional tests and
extension development hyprid triggering the deprecation message for the
deprecated `ext_emconf.php` file because not having the version available.

With [1] support for new `extra.typo3/cms.version` option would be added
to allow having the version set in a not destructive way for packagist
publishing and still avoiding the deprecation message when:

* functional tests are executed
* the extension is cloned in a classic mode installation

To be precise, the deprecation message is not simply silenced that way,
but instead only the `composer.json` is used and `ext_emconf.php` loading
omitted as long as the `extra.typo3/cms.Package.providesPackages` option
at least exists.

To full fill this the gerrit change is added as composer patch and the
`composer.json` modified to have the two extra configuration options set.

Some additional changes has been made to files, which adds them as
additional composer patches to have the patches applied in chain
correctly.

Used command(s):

```bash
bin/download-patch-from-gerrit.phpsh 93484 \
&& bin/download-patch-from-gerrit.phpsh 93536 \
&& composer config --json "extra"."typo3/cms"."Package" '{"providesPackages": {}}' \
&& composer config "extra"."typo3/cms"."version" '2.0.0'
```

* [1] [93536: [TASK] Allow extension version declaration in extra.version](https://review.typo3.org/c/Packages/TYPO3.CMS/+/93536)
