### PR TITLE
[TASK] DPL-158: Align included composer patches

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -101,7 +101,7 @@
         "typo3/cms-styleguide": "^13.4.10 || 14.2.*@dev",
         "typo3/cms-tstemplate": "^13.4.10 || 14.2.*@dev",
         "typo3/cms-workspaces": "^13.4.10 || 14.2.*@dev",
-        "typo3/testing-framework": "^9.4.0",
+        "typo3/testing-framework": "^9.5.0",
         "vaimo/composer-patches": "^6.0.1"
     },
     "autoload": {

--- a/patches/typo3-cms-core_93484_bugfix-strip-title-from-package-description-if-extracted.patch
+++ b/patches/typo3-cms-core_93484_bugfix-strip-title-from-package-description-if-extracted.patch
@@ -2,7 +2,7 @@
 @label [BUGFIX] Strip title from package description if extracted
 @link https://review.typo3.org/c/Packages/TYPO3.CMS/+/93484
 @version ~14.2.0
-@after patches/typo3-cms-core_93530_bugfix-avoid-undefined-property_-stdclass__version-warning.patch
+@after typo3-cms-core_93530_bugfix-avoid-undefined-property_-stdclass__version-warning.patch
 
 From 17f8256acba6eb1c5b4b3e2732b63dc891279ad0 Mon Sep 17 00:00:00 2001
 From: Benjamin Kott <benjamin.kott@outlook.com>

--- a/patches/typo3-cms-core_93536_task-allow-extension-version-declaration-in-extra.version.patch
+++ b/patches/typo3-cms-core_93536_task-allow-extension-version-declaration-in-extra.version.patch
@@ -2,7 +2,7 @@
 @label [TASK] Allow extension version declaration in extra.version
 @link https://review.typo3.org/c/Packages/TYPO3.CMS/+/93536
 @version ~14.2.0
-@after patches/typo3-cms-core_93484_bugfix-strip-title-from-package-description-if-extracted.patch
+@after typo3-cms-core_93484_bugfix-strip-title-from-package-description-if-extracted.patch
 
 From dcee72fe2e0ffb097d570d626e69c201ad05d403 Mon Sep 17 00:00:00 2001
 From: Helmut Hummel <typo3@helhum.io>


### PR DESCRIPTION
This change modifies the includes composer
patches and normalizes the `@after` patch
identifier to strip the `patches/` prefix.

Additionally the typo3/testing-framework
is updated now to the latest release.

Used command(s):

```bash
composer require --dev \
  'typo3/testing-framework':'^9.5.0'
```
