### PR TITLE
[TASK] DPL-158: Set extension title in `composer.json` description

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "web-vision/deepl-base",
     "type": "typo3-cms-extension",
-    "description": "TYPO3 Extension providing shared things across deepl related extensions, for example a shared point when overriding same TYPO3 backend fluid files are required and similar.",
+    "description": "DeepL Base - Provides shared things across deepl related extensions, for example a shared point when overriding same TYPO3 backend fluid files are required and similar.",
     "license": [
         "GPL-2.0-or-later"
     ],

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -21,10 +21,4 @@ $EM_CONF[$_EXTKEY] = [
         'conflicts' => [],
         'suggests' => [],
     ],
-    'autoload' => [
-        'psr-4' => [
-            'WebVision\\Deepl\\Base\\' => 'Classes',
-            'WebVision\\Deepl\\Base\\Core13\\Controller\\Backend\\' => 'Core13/Classes',
-        ],
-    ],
 ];


### PR DESCRIPTION
To avoid reading the legacy ext_emconf.php file even in
Composer mode, the extension title is now optionally pulled
from the composer.json description.

If the character sequence - (space, dash, space) is present
in description field in composer.json, then everything before
this sequence is used as title of the extension and the second
part is used as extension description. Note that only the first
occurrence of this sequence is evaluated, so it remains possible
to have this inside the extension description if required.

This change follows the recommendation and prefixes the extension
title now in the description field for `composer.json` and it is
now also aligned to be the same in `composer.json` and `ext_emconf.php`.

[1] https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/14.0/Breaking-108304-PopulateExtensionTitleFromComposerJson.html
