### PR TITLE
[TASK] Drop obsolete `typo3/cms-setup` dependency

### DIFF
--- a/Tests/Functional/Core13/Controller/Backend/LocalizationControllerTest.php
+++ b/Tests/Functional/Core13/Controller/Backend/LocalizationControllerTest.php
@@ -28,10 +28,6 @@ final class LocalizationControllerTest extends FunctionalTestCase
         'FR' => ['id' => 2, 'title' => 'Französisch', 'locale' => 'fr_FR.UTF-8'],
     ];
 
-    protected array $coreExtensionsToLoad = [
-        'typo3/cms-setup',
-    ];
-
     protected array $testExtensionsToLoad = [
         'web-vision/deepl-base',
     ];

--- a/Tests/Functional/ExtensionLoadedTest.php
+++ b/Tests/Functional/ExtensionLoadedTest.php
@@ -14,10 +14,6 @@ final class ExtensionLoadedTest extends FunctionalTestCase
 {
     private const ALLOWED_MAJOR_VERSIONS = [13, 14];
 
-    protected array $coreExtensionsToLoad = [
-        'typo3/cms-setup',
-    ];
-
     protected array $testExtensionsToLoad = [
         'web-vision/deepl-base',
     ];

--- a/Tests/Functional/ViewHelpers/ExtensionActiveViewHelperTest.php
+++ b/Tests/Functional/ViewHelpers/ExtensionActiveViewHelperTest.php
@@ -18,10 +18,6 @@ final class ExtensionActiveViewHelperTest extends FunctionalTestCase
 {
     protected bool $initializeDatabase = false;
 
-    protected array $coreExtensionsToLoad = [
-        'typo3/cms-setup',
-    ];
-
     protected array $testExtensionsToLoad = [
         'web-vision/deepl-base',
     ];

--- a/Tests/Functional/ViewHelpers/InjectVariablesViewHelperTest.php
+++ b/Tests/Functional/ViewHelpers/InjectVariablesViewHelperTest.php
@@ -16,10 +16,6 @@ final class InjectVariablesViewHelperTest extends FunctionalTestCase
 {
     protected bool $initializeDatabase = false;
 
-    protected array $coreExtensionsToLoad = [
-        'typo3/cms-setup',
-    ];
-
     protected array $testExtensionsToLoad = [
         'web-vision/deepl-base',
     ];

--- a/composer.json
+++ b/composer.json
@@ -69,8 +69,7 @@
         "ext-json": "*",
         "typo3/cms-backend": "~13.4.28@dev || ~14.3.0@dev",
         "typo3/cms-core": "~13.4.28@dev || ~14.3.0@dev",
-        "typo3/cms-fluid": "~13.4.28@dev || ~14.3.0@dev",
-        "typo3/cms-setup": "~13.4.28@dev || ~14.3.0@dev"
+        "typo3/cms-fluid": "~13.4.28@dev || ~14.3.0@dev"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.94.2",

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -3,12 +3,12 @@
 $EM_CONF[$_EXTKEY] = [
     'title' => 'DeepL Base',
     'description' => 'Provides shared things across deepl related extensions, for example a shared point when overriding same TYPO3 backend fluid files are required and similar.',
-    'category' => 'backend',
-    'author' => 'web-vision GmbH Team',
-    'author_company' => 'web-vision GmbH',
-    'author_email' => 'hello@web-vision.de',
-    'state' => 'stable',
     'version' => '2.0.1',
+    'category' => 'backend',
+    'state' => 'stable',
+    'author' => 'web-vision GmbH Team',
+    'author_email' => 'hello@web-vision.de',
+    'author_company' => 'web-vision GmbH',
     'constraints' => [
         'depends' => [
             'php' => '8.1.0-8.5.99',
@@ -16,9 +16,6 @@ $EM_CONF[$_EXTKEY] = [
             'backend' => '13.4.28-14.3.99',
             'extbase' => '13.4.28-14.3.99',
             'fluid' => '13.4.28-14.3.99',
-            'setup' => '13.4.27-14.3.99',
         ],
-        'conflicts' => [],
-        'suggests' => [],
     ],
 ];


### PR DESCRIPTION
Used command(s):

```bash
pkw extemconf:constraints:unset depends setup ./ext_emconf.php && \
composer remove --no-update 'typo3/cms-setup'
```
