### PR TITLE
[TASK] DPL-158: Adjust github actions

### DIFF
--- a/.github/workflows/testcore12.yml
+++ b/.github/workflows/testcore12.yml
@@ -50,7 +50,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version: [ '8.1', '8.2', '8.3', '8.4' ]
+        php-version: [ '8.1', '8.4' ]
     steps:
       - name: "Checkout"
         uses: actions/checkout@v4


### PR DESCRIPTION
This change reduces the used php versions for test
executions for TYPO3 v12 to PHP 8.1 & PHP 8.4 and
matches the lowest and highest supported PHP version
only. This reduces waiting time on pull-requests.
